### PR TITLE
[ECO-1364] Double fan 

### DIFF
--- a/flowtypes/broadcast.js
+++ b/flowtypes/broadcast.js
@@ -164,6 +164,7 @@ declare type ChatState = {
  */
 
 declare type BroadcastAction =
+  { type: 'FAN_TRANSITION', fanTransition: boolean } |
   { type: 'SET_BROADCAST_EVENT', event: BroadcastEvent } |
   { type: 'RESET_BROADCAST_EVENT' } |
   { type: 'BACKSTAGE_CONNECTED', connected: boolean } |

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat:300,400,600,700|Open+Sans:300,300i,400">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css">
-    <link rel="stylesheet prefetch" href="https://releases.flowplayer.org/6.0.5/skin/minimalist.css">
+    <link rel="stylesheet prefetch" href="//releases.flowplayer.org/7.2.1/skin/skin.css">
     <script src="https://static.opentok.com/v2/js/opentok.min.js"></script>
     <!--
       Notice the use of %PUBLIC_URL% in the tag above.

--- a/src/actions/broadcast.js
+++ b/src/actions/broadcast.js
@@ -12,6 +12,16 @@ const avPropertyChanged: ActionCreator = (participantType: UserRole, update: Par
   update,
 });
 
+const startFanTransition: ActionCreator = (): BroadcastAction => ({
+  type: 'FAN_TRANSITION',
+  fanTransition: true,
+});
+
+const stopFanTransition: ActionCreator = (): BroadcastAction => ({
+  type: 'FAN_TRANSITION',
+  fanTransition: false,
+});
+
 const setReconnecting: ActionCreator = (): BroadcastAction => ({
   type: 'SET_RECONNECTING',
   reconnecting: true,
@@ -121,7 +131,8 @@ const toggleParticipantProperty: ThunkActionCreator = (participantType: Particip
  * Kick fan from stage or backstage feeds
  */
 const forceFanToDisconnect: ThunkActionCreator = (fan: ActiveFan): Thunk =>
-  () => {
+  (dispatch: Dispatch) => {
+    dispatch(stopFanTransition());
     const stream = opentok.getStreamById('backstage', fan.streamId);
     opentok.forceDisconnect('backstage', stream.connection);
   };
@@ -298,4 +309,6 @@ module.exports = {
   stopElapsedTime,
   startElapsedTime,
   forceFanToDisconnect,
+  startFanTransition,
+  stopFanTransition,
 };

--- a/src/actions/fan.js
+++ b/src/actions/fan.js
@@ -279,6 +279,7 @@ const onSignal = (dispatch: Dispatch, getState: GetState): SignalListener =>
       case 'disconnect':
         {
           dispatch(leaveTheLine());
+          dispatch(resetAlert());
           const message =
             `Thank you for participating, you are no longer sharing video/voice.
             You can continue to watch the session at your leisure.`;
@@ -370,6 +371,7 @@ const opentokConfig = (userCredentials: UserCredentials, dispatch: Dispatch, get
       } else {
         dispatch(setDisconnected());
       }
+      dispatch(resetAlert());
     });
   };
 

--- a/src/actions/fan.js
+++ b/src/actions/fan.js
@@ -196,13 +196,13 @@ const removeActiveFanRecord: ThunkActionCreator = (event: BroadcastEvent): Thunk
  */
 const leaveTheLine: ThunkActionCreator = (): Thunk =>
   async (dispatch: Dispatch, getState: GetState): AsyncVoid => {
-    dispatch(setFanStatus('disconnecting'));
     const state = getState();
+    const fanOnStage = R.equals('stage', R.path(['fan', 'status'], state));
     const event = R.path(['broadcast', 'event'], state);
     const isLive = R.equals('live', event.status);
-    const fanOnStage = R.equals('stage', R.path(['fan', 'status'], state));
     await opentok.disconnectFromInstance('backstage');
     if (fanOnStage) isLive ? await opentok.unpublish('stage') : await opentok.endCall('stage');
+    dispatch(setFanStatus('disconnecting'));
     await dispatch(cancelNetworkTest());
     await dispatch(removeActiveFanRecord(event));
     dispatch(setBackstageConnected(false));

--- a/src/actions/fan.js
+++ b/src/actions/fan.js
@@ -281,7 +281,7 @@ const onSignal = (dispatch: Dispatch, getState: GetState): SignalListener =>
           dispatch(leaveTheLine());
           const message =
             `Thank you for participating, you are no longer sharing video/voice.
-            You can continue to watch the session at your leisure.'`;
+            You can continue to watch the session at your leisure.`;
           toastr.success(message, { showCloseButton: false });
           break;
         }

--- a/src/actions/fan.js
+++ b/src/actions/fan.js
@@ -728,6 +728,7 @@ const getInLine: ThunkActionCreator = (): Thunk =>
       allowEscapeKey: false,
       html: true,
       confirmButtonColor: '#00a3e3',
+      onCancel: (): void => dispatch(connectToBackstage('Anonymous')),
       onConfirm: (inputValue: string): void => dispatch(connectToBackstage(inputValue || 'Anonymous')),
     });
     dispatch(setFanStatus('connecting'));

--- a/src/actions/producer.js
+++ b/src/actions/producer.js
@@ -28,6 +28,8 @@ import {
   onChatMessage,
   monitorVolume,
   startCountdown,
+  startFanTransition,
+  stopFanTransition,
 } from './broadcast';
 
 let analytics;
@@ -567,6 +569,7 @@ const kickFanFromFeed: ThunkActionCreator = (participantType: FanParticipantType
 
 const sendToBackstage: ThunkActionCreator = (fan: ActiveFan): Thunk =>
   async (dispatch: Dispatch, getState: GetState): AsyncVoid => {
+    dispatch(startFanTransition());
     /* Remove the current backstagefan */
     const { broadcast } = getState();
     const participant = R.path(['participants', 'backstageFan'], broadcast);
@@ -588,8 +591,9 @@ const sendToBackstage: ThunkActionCreator = (fan: ActiveFan): Thunk =>
     const stream = opentok.getStreamById('backstage', fan.streamId);
 
     /* Add the participant to the backstage fan feed and start subscribing */
+    await opentok.subscribe('backstage', stream, { subscribeToAudio: false });
     dispatch(updateParticipants('backstageFan', 'streamCreated', stream));
-    opentok.subscribe('backstage', stream, { subscribeToAudio: false });
+    dispatch(stopFanTransition());
 
     /* Let the fan know that he is on backstage */
     signal('backstage', { type: 'joinBackstage', to: stream.connection });
@@ -622,6 +626,7 @@ const sendToStage: ThunkActionCreator = (): Thunk =>
     const fan = R.findLast(isBackstage)(R.values(currentFans));
     if (fan) {
       analytics.log(logAction.producerMovesFanOnstage, logVariation.attempt);
+      dispatch({ type: 'START_FAN_TRANSITION' });
       const stream = opentok.getStreamById('backstage', fan.streamId);
       const { event } = broadcast;
       const { adminId, fanUrl } = event;
@@ -642,6 +647,11 @@ const sendToStage: ThunkActionCreator = (): Thunk =>
 
       /* Send the first signal to the fan */
       signal('backstage', { type: 'joinHost', to: stream.connection });
+
+      /* Stop subscribing the backstage fan */
+      console.log('stream', stream);
+      await opentok.unsubscribe('backstage', stream);
+      dispatch({ type: 'BROADCAST_PARTICIPANT_LEFT', participantType: 'backstageFan' });
 
       /* update the record in firebase */
       try {

--- a/src/actions/producer.js
+++ b/src/actions/producer.js
@@ -626,7 +626,6 @@ const sendToStage: ThunkActionCreator = (): Thunk =>
     const fan = R.findLast(isBackstage)(R.values(currentFans));
     if (fan) {
       analytics.log(logAction.producerMovesFanOnstage, logVariation.attempt);
-      dispatch({ type: 'START_FAN_TRANSITION' });
       const stream = opentok.getStreamById('backstage', fan.streamId);
       const { event } = broadcast;
       const { adminId, fanUrl } = event;
@@ -649,7 +648,6 @@ const sendToStage: ThunkActionCreator = (): Thunk =>
       signal('backstage', { type: 'joinHost', to: stream.connection });
 
       /* Stop subscribing the backstage fan */
-      console.log('stream', stream);
       await opentok.unsubscribe('backstage', stream);
       dispatch({ type: 'BROADCAST_PARTICIPANT_LEFT', participantType: 'backstageFan' });
 

--- a/src/components/Broadcast/Fan/components/FanHLSPlayer.js
+++ b/src/components/Broadcast/Fan/components/FanHLSPlayer.js
@@ -19,7 +19,7 @@ class FanHLSPlayer extends Component {
 
   componentWillReceiveProps() {
     const { isLive } = this.props;
-    if (isLive) this.start();
+    if (isLive && !window.flowplayer) this.start();
   }
 
   start() {
@@ -45,14 +45,14 @@ class FanHLSPlayer extends Component {
   render(): ReactComponent {
     return (
       <div className="FanHLSPlayer">
-        <div id="hlsjslive" />
+        <div id="hlsjslive" className="fp-minimal" />
       </div>);
   }
 }
 
 export default scriptLoader(
   [
-    'https://releases.flowplayer.org/6.0.5/flowplayer.min.js',
+    'https://releases.flowplayer.org/7.2.1/flowplayer.min.js',
     'https://releases.flowplayer.org/hlsjs/flowplayer.hlsjs.min.js',
   ],
   '/assets/bootstrap-markdown.js',

--- a/src/components/Broadcast/Fan/components/FanHeader.js
+++ b/src/components/Broadcast/Fan/components/FanHeader.js
@@ -32,10 +32,11 @@ const FanHeader = (props: Props): ReactComponent => {
     disconnected,
     postProduction,
   } = props;
-  const displayGetInLineButton = ableToJoin && status !== 'closed' && !postProduction && !disconnected;
+  const isConnecting = fanStatus === 'connecting';
+  const isDisconnecting = fanStatus === 'disconnecting';
+  const displayGetInLineButton = ableToJoin && status !== 'closed' && !isConnecting && !isDisconnecting && !postProduction && !disconnected;
   const inPrivateCallWith = R.propOr(null, 'isWith', privateCall || {});
   const onStageUserInPrivateCall = !inPrivateCall && R.equals('stage', fanStatus) && inPrivateCallWith && isUserOnStage(inPrivateCallWith);
-  const isConnecting = fanStatus === 'connecting';
   const getInLineButton = (): ReactComponent =>
     !backstageConnected ?
       !isConnecting && <button className="btn green getInLine" onClick={getInLine}>GET IN LINE</button> :

--- a/src/components/Broadcast/Fan/components/FanHeader.js
+++ b/src/components/Broadcast/Fan/components/FanHeader.js
@@ -34,9 +34,10 @@ const FanHeader = (props: Props): ReactComponent => {
   } = props;
   const isConnecting = fanStatus === 'connecting';
   const isDisconnecting = fanStatus === 'disconnecting';
-  const displayGetInLineButton = ableToJoin && status !== 'closed' && !isConnecting && !isDisconnecting && !postProduction && !disconnected;
+  const isOnStage = fanStatus === 'stage';
+  const displayGetInLineButton = ableToJoin && status !== 'closed' && !isOnStage && !isConnecting && !isDisconnecting && !postProduction && !disconnected;
   const inPrivateCallWith = R.propOr(null, 'isWith', privateCall || {});
-  const onStageUserInPrivateCall = !inPrivateCall && R.equals('stage', fanStatus) && inPrivateCallWith && isUserOnStage(inPrivateCallWith);
+  const onStageUserInPrivateCall = !inPrivateCall && isOnStage && inPrivateCallWith && isUserOnStage(inPrivateCallWith);
   const getInLineButton = (): ReactComponent =>
     !backstageConnected ?
       !isConnecting && <button className="btn green getInLine" onClick={getInLine}>GET IN LINE</button> :

--- a/src/components/Broadcast/Fan/components/FanStatusBar.js
+++ b/src/components/Broadcast/Fan/components/FanStatusBar.js
@@ -16,6 +16,10 @@ const FanStatusBar = (props: Props): ReactComponent => {
       statusText = 'Connecting ...';
       statusClass = 'lightBlue';
       break;
+    case 'disconnecting':
+      statusText = 'Disconnecting ...';
+      statusClass = 'lightBlue';
+      break;
     case 'inLine':
       statusText = 'You Are In Line';
       statusClass = 'lightBlue';

--- a/src/components/Broadcast/Fan/components/FanStatusBar.js
+++ b/src/components/Broadcast/Fan/components/FanStatusBar.js
@@ -17,7 +17,7 @@ const FanStatusBar = (props: Props): ReactComponent => {
       statusClass = 'lightBlue';
       break;
     case 'disconnecting':
-      statusText = 'Disconnecting ...';
+      statusText = 'Leaving The Line...';
       statusClass = 'lightBlue';
       break;
     case 'inLine':

--- a/src/components/Broadcast/Producer/components/ActiveFanList.js
+++ b/src/components/Broadcast/Producer/components/ActiveFanList.js
@@ -41,8 +41,8 @@ type ActiveFanActions = {
 };
 
 const snapshot = 'https://assets.tokbox.com/solutions/images/tokbox.png';
-type FanProps = { fan: ActiveFan, sortable: boolean, actions: ActiveFanActions, backstageFan: FanParticipantState };
-const Fan = SortableElement(({ fan, sortable, actions }: FanProps): ReactComponent => {
+type FanProps = { fan: ActiveFan, sortable: boolean, actions: ActiveFanActions, backstageFan: FanParticipantState, fanTransition: boolean };
+const Fan = SortableElement(({ fan, sortable, actions, fanTransition }: FanProps): ReactComponent => {
   const { chat, sendFanToBackstage, sendFanToStage, kickFan, connectCall, forceDisconnect } = actions;
   const { inPrivateCall, isOnStage, isBackstage } = fan;
   const privateCall = R.partial(connectCall, [fanTypeForActiveFan(fan), fan.id]);
@@ -62,7 +62,7 @@ const Fan = SortableElement(({ fan, sortable, actions }: FanProps): ReactCompone
           { networkQuality(fan.networkQuality)}
         </div>
         <div className="actions">
-          {!isBackstage && !isOnStage && <button className="btn white" onClick={R.partial(sendFanToBackstage, [fan])}>Send to backstage</button>}
+          {!isBackstage && !isOnStage && <button disabled={fanTransition} className="btn white" onClick={R.partial(sendFanToBackstage, [fan])}>Send to backstage</button>}
           {isBackstage && <button className="btn white" onClick={R.partial(sendFanToStage, [fan])}>Send to stage</button>}
           {!isOnStage && <button className="btn white" onClick={R.partial(privateCall, [fan])}>{ inPrivateCall ? 'Hang Up' : 'Call'}</button>}
           <button className="btn white" onClick={R.partial(chat, [fan])}>Chat</button>
@@ -73,20 +73,20 @@ const Fan = SortableElement(({ fan, sortable, actions }: FanProps): ReactCompone
   );
 });
 
-type SortableContainerProps = { fans: ActiveFan[], actions: ActiveFanActions, backstageFan: FanParticipantState };
-const SortableFanList: { fans: ActiveFan[], actions: ActiveFanActions, backstageFan: FanParticipantState } => ReactComponent =
-  SortableContainer(({ fans, actions, backstageFan }: SortableContainerProps): ReactComponent => {
+type SortableContainerProps = { fans: ActiveFan[], actions: ActiveFanActions, backstageFan: FanParticipantState, fanTransition: boolean };
+const SortableFanList: { fans: ActiveFan[], actions: ActiveFanActions, backstageFan: FanParticipantState, fanTransition: boolean } => ReactComponent =
+  SortableContainer(({ fans, actions, backstageFan, fanTransition }: SortableContainerProps): ReactComponent => {
     const sortable = fans.length > 1;
     return (
       <ul className={classNames('ActiveFanList', { sortable })} >
         {fans.map((fan: ActiveFan, index: number): ReactComponent => (
-          <Fan key={`fan-${fan.id}`} index={index} fan={fan} sortable={sortable} actions={actions} backstageFan={backstageFan} /> // eslint-disab
+          <Fan key={`fan-${fan.id}`} index={index} fan={fan} sortable={sortable} actions={actions} backstageFan={backstageFan} fanTransition={fanTransition} /> // eslint-disab
         ))}
       </ul>
     );
   });
 
-type BaseProps = { activeFans: ActiveFans, backstageFan: FanParticipantState };
+type BaseProps = { activeFans: ActiveFans, backstageFan: FanParticipantState, fanTransition: boolean };
 type DispatchProps = {
   reorderFans: ActiveFanOrderUpdate => void,
   actions: ActiveFanActions
@@ -108,13 +108,13 @@ class ActiveFanList extends Component {
 
   render(): ReactComponent {
     const { onSortEnd } = this;
-    const { actions, backstageFan } = this.props;
+    const { actions, backstageFan, fanTransition } = this.props;
     const { map, order } = this.props.activeFans;
     const buildList = (acc: ActiveFan[], id: UserId): ActiveFan[] => R.append(R.prop(id, map), acc);
     return (
       <SortableFanList
         fans={R.reduce(buildList, [], order)}
-        onSortEnd={onSortEnd} actions={actions} backstageFan={backstageFan}
+        onSortEnd={onSortEnd} actions={actions} backstageFan={backstageFan} fanTransition={fanTransition}
         lockAxis="y"
         helperClass="ProducerSidePanel-reordering"
       />
@@ -125,6 +125,7 @@ class ActiveFanList extends Component {
 const mapStateToProps = (state: State): BaseProps => ({
   activeFans: state.broadcast.activeFans,
   backstageFan: state.broadcast.participants.backstageFan,
+  fanTransition: state.broadcast.fanTransition,
 });
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps> = (dispatch: Dispatch): DispatchProps => ({

--- a/src/reducers/broadcast.js
+++ b/src/reducers/broadcast.js
@@ -61,6 +61,7 @@ const initialState = (): BroadcastState => ({
   reconnecting: false,
   disconnected: false,
   elapsedTime: '--:--:--',
+  fanTransition: false,
 });
 
 const activeFansUpdate = (activeFans: ActiveFans, update: ActiveFanMap): ActiveFans => {
@@ -88,6 +89,8 @@ const updateFanOrder = (activeFans: ActiveFans, update: ActiveFanOrderUpdate): A
 
 const broadcast = (state: BroadcastState = initialState(), action: BroadcastAction): BroadcastState => {
   switch (action.type) {
+    case 'FAN_TRANSITION':
+      return R.assoc('fanTransition', action.fanTransition, state);
     case 'SET_RECONNECTING':
       return R.assoc('reconnecting', action.reconnecting, state);
     case 'SET_DISCONNECTED':


### PR DESCRIPTION
This PR fixes some issues on the fan and the producer.

Fixes for the fan view:
Added the status bar `Leaving The Line....` when the user clicks on Leave the line. In addition I'm adding 3 secs of delay before showing the Get in the line button. This is to give time to the disconnection process and to avoid to let the user get in the line and leave the rapidly. 
Fixes for the producer view:
1- While clicking on Send to backstage on a Fan, I'm not allowing to click on this button or any other `Send to backstage` of other fan until the transition of the first fan finishes. This is to avoid problems when clicking rapidly on this button, that was producing several subscribers.
2- When the producer sends the fan to on stage, I'm unsubcribing the backstage fan. This way I'm avoiding to be able to press on any other button on the backstage fan feed (private call, toggle camera, etc).

